### PR TITLE
feat: expose wrapper as top level

### DIFF
--- a/IMED/__init__.py
+++ b/IMED/__init__.py
@@ -1,1 +1,5 @@
-#
+from .ST_all import standardizingTrans
+
+__all__ = [
+    "standardizingTrans",
+]


### PR DESCRIPTION
This makes it easer to use, as the user now can just
```
from IMED import standardizingTrans
```
without the need of knowling the namefiles.
I think more functions sould also be added as top level ones thought.